### PR TITLE
fix: use correct server ID in content-type-mappings

### DIFF
--- a/ca.mt.gore/plugin.xml
+++ b/ca.mt.gore/plugin.xml
@@ -40,12 +40,13 @@
          point="org.eclipse.lsp4e.languageServer">
       <contentTypeMapping
             contentType="org.golang"
-            id="ca.mt.gore.server.go"
+            id="ca.mt.gore.server"
             languageId="go">
       </contentTypeMapping>
       <contentTypeMapping
             contentType="org.golang.gomod"
-            id="ca.mt.gore.server">
+            id="ca.mt.gore.server"
+            languageId="go">
       </contentTypeMapping>
       <server
             class="ca.mt.gore.GoServer"


### PR DESCRIPTION
I unwittingly changed the server ID in #5 when adding a content-type mapping for `go.mod` and `go.sum` files.  This leads to odd `server 'ca.mt.gore.server.go' not available` errors on startup.